### PR TITLE
fix: add address zero check to contribution owners proposals

### DIFF
--- a/contracts/FragmentNFT.sol
+++ b/contracts/FragmentNFT.sol
@@ -288,7 +288,7 @@ contract FragmentNFT is IFragmentNFT, ERC721Upgradeable {
 
     for (uint256 i; i < owners.length; i++) {
       address owner = owners[i];
-      if (owner == address(0)) revert ZERO_ADDRESS();
+      if (owner == address(0)) continue;
 
       uint256 id = ++_mintCounter;
       bytes32 tag = tags_[i];

--- a/tests/DatasetNFT.spec.ts
+++ b/tests/DatasetNFT.spec.ts
@@ -1031,7 +1031,7 @@ export default async function suite(): Promise<void> {
           .withArgs(lastFragmentPendingId + 3n, tagData);
       });
 
-      it('Should proposeManyFragments() revert if one of the contributors is address zero', async () => {
+      it('Should proposeManyFragments() skip contributor if it is the zero address and continue', async () => {
         const tagSchemas = utils.encodeTag('dataset.schemas');
         const tagRows = utils.encodeTag('dataset.rows');
         const tagData = utils.encodeTag('dataset.data');
@@ -1059,7 +1059,12 @@ export default async function suite(): Promise<void> {
             tags,
             proposeManySignature
           )
-        ).to.be.revertedWithCustomError(DatasetFragment_, 'ZERO_ADDRESS');
+        )
+          .to.emit(DatasetFragment_, 'FragmentPending')
+          .withArgs(lastFragmentPendingId + 1n, tagSchemas)
+          .to.emit(DatasetFragment_, 'FragmentPending')
+          // tagData fragment id should be lastFragmentPendingId + 3n, but it's lastFragmentPendingId + 2n
+          .withArgs(lastFragmentPendingId + 2n, tagData);
       });
 
       it('Should revert contributor propose multiple fragments if proposes length is not correct', async function () {


### PR DESCRIPTION
## Summary
 
- [x] Add address zero check to contribution to owners in `propose()` and `proposeMany()` functions
- [x] Add tests


resolves #37 