### PR TITLE
refactor: use IVerifierManager into AcceptManuallyVerifier 

### DIFF
--- a/contracts/interfaces/IVerifierManager.sol
+++ b/contracts/interfaces/IVerifierManager.sol
@@ -11,4 +11,13 @@ interface IVerifierManager is IDatasetLinkInitializable {
    * @param tag Tag to verify
    */
   function propose(uint256 id, bytes32 tag) external;
+
+  /**
+   * @notice Resolves a single contribution proposal
+   * @dev Only callable by the configured Verifier for the associated tag.
+   * Emits a {FragmentResolved} event.
+   * @param id The ID of the pending Fragment associated with the contribution proposal
+   * @param accept Flag to indicate acceptance (`true`) or rejection (`true`)
+   */
+  function resolve(uint256 id, bool accept) external;
 }

--- a/contracts/verifier/AcceptManuallyVerifier.sol
+++ b/contracts/verifier/AcceptManuallyVerifier.sol
@@ -5,7 +5,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {IDatasetNFT} from "../interfaces/IDatasetNFT.sol";
 import {IFragmentNFT} from "../interfaces/IFragmentNFT.sol";
 import {IVerifier} from "../interfaces/IVerifier.sol";
-import {VerifierManager} from "./VerifierManager.sol";
+import {IVerifierManager} from "../interfaces/IVerifierManager.sol";
 import {
   ERC2771ContextExternalForwarderSourceUpgradeable
 } from "../utils/ERC2771ContextExternalForwarderSourceUpgradeable.sol";
@@ -79,7 +79,7 @@ contract AcceptManuallyVerifier is IVerifier, ERC2771ContextExternalForwarderSou
     address fragmentOwner = IFragmentNFT(fragmentNFT).pendingFragmentOwners(id);
 
     if (datasetOwner == fragmentOwner) {
-      VerifierManager vm = VerifierManager(dataset.verifierManager(IFragmentNFT(fragmentNFT).datasetId()));
+      IVerifierManager vm = IVerifierManager(dataset.verifierManager(IFragmentNFT(fragmentNFT).datasetId()));
       _pendingFragments[fragmentNFT].remove(id);
       vm.resolve(id, true);
       emit FragmentResolved(fragmentNFT, id, true);
@@ -95,7 +95,7 @@ contract AcceptManuallyVerifier is IVerifier, ERC2771ContextExternalForwarderSou
    * @param accept Flag to indicate acceptance (`true`) or rejection (`true`)
    */
   function resolve(address fragmentNFT, uint256 id, bool accept) external onlyDatasetOwner(fragmentNFT) {
-    VerifierManager vm = VerifierManager(dataset.verifierManager(IFragmentNFT(fragmentNFT).datasetId()));
+    IVerifierManager vm = IVerifierManager(dataset.verifierManager(IFragmentNFT(fragmentNFT).datasetId()));
     _pendingFragments[fragmentNFT].remove(id);
     vm.resolve(id, accept);
     emit FragmentResolved(fragmentNFT, id, accept);
@@ -110,7 +110,7 @@ contract AcceptManuallyVerifier is IVerifier, ERC2771ContextExternalForwarderSou
    * @param accept Flag to indicate acceptance (`true`) or rejection (`true`)
    */
   function resolveMany(address fragmentNFT, uint256[] memory ids, bool accept) external onlyDatasetOwner(fragmentNFT) {
-    VerifierManager vm = VerifierManager(dataset.verifierManager(IFragmentNFT(fragmentNFT).datasetId()));
+    IVerifierManager vm = IVerifierManager(dataset.verifierManager(IFragmentNFT(fragmentNFT).datasetId()));
     for (uint256 i; i < ids.length; i++) {
       uint256 id = ids[i];
       _pendingFragments[fragmentNFT].remove(id);


### PR DESCRIPTION
## Summary
 
- [x] Replace `VerifierManager` with `IVerifierManager` interface to save deployed bytecode size
- [x] Add `resolve()` method to `IVerifierManager` interface


resolves #52 