### PR TITLE
feat: add and emit events for tag verifiers and adjust tests

### DIFF
--- a/contracts/verifier/VerifierManager.sol
+++ b/contracts/verifier/VerifierManager.sol
@@ -26,6 +26,8 @@ contract VerifierManager is IVerifierManager, ERC2771ContextExternalForwarderSou
 
   event FragmentPending(uint256 id);
   event FragmentResolved(uint256 id, bool accept);
+  event FragmentTagDefaultVerifierSet(address verifier);
+  event FragmentTagVerifierSet(address indexed verifier, bytes32 tag);
 
   IDatasetNFT public dataset;
   uint256 public datasetId;
@@ -69,6 +71,7 @@ contract VerifierManager is IVerifierManager, ERC2771ContextExternalForwarderSou
    */
   function setDefaultVerifier(address defaultVerifier_) external onlyDatasetOwner {
     defaultVerifier = defaultVerifier_;
+    emit FragmentTagDefaultVerifierSet(defaultVerifier_);
   }
 
   /**
@@ -80,6 +83,7 @@ contract VerifierManager is IVerifierManager, ERC2771ContextExternalForwarderSou
    */
   function setTagVerifier(bytes32 tag, address verifier) external onlyDatasetOwner {
     verifiers[tag] = verifier;
+    emit FragmentTagVerifierSet(verifier, tag);
   }
 
   /**
@@ -92,6 +96,7 @@ contract VerifierManager is IVerifierManager, ERC2771ContextExternalForwarderSou
     if (tags.length != verifiers_.length) revert ARRAY_LENGTH_MISMATCH();
     for (uint256 i; i < tags.length; i++) {
       verifiers[tags[i]] = verifiers_[i];
+      emit FragmentTagVerifierSet(verifiers_[i], tags[i]);
     }
   }
 

--- a/tests/FragmentNFT.spec.ts
+++ b/tests/FragmentNFT.spec.ts
@@ -241,10 +241,14 @@ export default async function suite(): Promise<void> {
 
       expect(await DatasetVerifierManager_.verifiers(schemaRowsTag)).to.be.equal(ZeroAddress);
 
-      await DatasetVerifierManager_.connect(users_.datasetOwner).setTagVerifier(
-        schemaRowsTag,
-        acceptManuallyVerifierAddress
-      );
+      await expect(
+        DatasetVerifierManager_.connect(users_.datasetOwner).setTagVerifier(
+          schemaRowsTag,
+          acceptManuallyVerifierAddress
+        )
+      )
+        .to.emit(DatasetVerifierManager_, 'FragmentTagVerifierSet')
+        .withArgs(acceptManuallyVerifierAddress, schemaRowsTag);
 
       expect(await DatasetVerifierManager_.verifiers(schemaRowsTag)).to.be.equal(
         acceptManuallyVerifierAddress
@@ -260,10 +264,16 @@ export default async function suite(): Promise<void> {
       expect(await DatasetVerifierManager_.verifiers(schemaRowsTag)).to.be.equal(ZeroAddress);
       expect(await DatasetVerifierManager_.verifiers(schemaColsTag)).to.be.equal(ZeroAddress);
 
-      await DatasetVerifierManager_.connect(users_.datasetOwner).setTagVerifiers(
-        [schemaRowsTag, schemaColsTag],
-        [acceptManuallyVerifierAddress, acceptManuallyVerifierAddress]
-      );
+      await expect(
+        DatasetVerifierManager_.connect(users_.datasetOwner).setTagVerifiers(
+          [schemaRowsTag, schemaColsTag],
+          [acceptManuallyVerifierAddress, acceptManuallyVerifierAddress]
+        )
+      )
+        .to.emit(DatasetVerifierManager_, 'FragmentTagVerifierSet')
+        .withArgs(acceptManuallyVerifierAddress, schemaRowsTag)
+        .to.emit(DatasetVerifierManager_, 'FragmentTagVerifierSet')
+        .withArgs(acceptManuallyVerifierAddress, schemaColsTag);
 
       expect(await DatasetVerifierManager_.verifiers(schemaRowsTag)).to.be.equal(
         acceptManuallyVerifierAddress
@@ -322,6 +332,18 @@ export default async function suite(): Promise<void> {
           [acceptManuallyVerifierAddress]
         )
       ).to.be.revertedWithCustomError(DatasetVerifierManager_, 'ARRAY_LENGTH_MISMATCH');
+    });
+
+    it('Should data set owner set a default tag verifier', async function () {
+      const acceptManuallyVerifierAddress = await AcceptManuallyVerifier_.getAddress();
+
+      await expect(DatasetVerifierManager_.setDefaultVerifier(acceptManuallyVerifierAddress))
+        .to.emit(DatasetVerifierManager_, 'FragmentTagDefaultVerifierSet')
+        .withArgs(acceptManuallyVerifierAddress);
+
+      const defaultVerifier = await DatasetVerifierManager_.defaultVerifier();
+
+      expect(defaultVerifier).to.equal(acceptManuallyVerifierAddress);
     });
 
     it('Should revert fragment propose if verifier is not set', async function () {


### PR DESCRIPTION
## Summary
 
- [x] Emit events for `setDefaultVerifier()`,`setTagVerifier()` and `setTagVerifiers()` functions
- [x] Adjust tests with checking events emissions

resolves #38 