### PR TITLE
fix: add check for max subscription duration for extending subscription

### DIFF
--- a/contracts/subscription/GenericSingleDatasetSubscriptionManager.sol
+++ b/contracts/subscription/GenericSingleDatasetSubscriptionManager.sol
@@ -383,9 +383,8 @@ abstract contract GenericSingleDatasetSubscriptionManager is
       newDurationInDays = extraDurationInDays;
     }
 
-    newDurationInDays = newDurationInDays <= MAX_SUBSCRIPTION_DURATION_IN_DAYS
-      ? newDurationInDays
-      : MAX_SUBSCRIPTION_DURATION_IN_DAYS;
+    if (newDurationInDays > MAX_SUBSCRIPTION_DURATION_IN_DAYS)
+      revert SUBSCRIPTION_DURATION_INVALID(1, MAX_SUBSCRIPTION_DURATION_IN_DAYS, newDurationInDays);
 
     uint256 newConsumers = sd.paidConsumers + extraConsumers;
     (, uint256 newFee) = _calculateFee(newDurationInDays, newConsumers);


### PR DESCRIPTION
## Summary
 
- [x] added check for `newDurationInDays` and `MAX_SUBSCRIPTION_DURATION_IN_DAYS` for extending subscription and ensure that subscriptioon has a duration at most of 365 days
- [x] added tests
- [x] cherry-picked commit from #98 to use variables instead of literal numbers

resolves #49 