### PR TITLE
fix: adjust ERC721Enumerable upgradability in SubscriptionManager

### DIFF
--- a/contracts/interfaces/ISubscriptionManager.sol
+++ b/contracts/interfaces/ISubscriptionManager.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {
+  IERC721EnumerableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/IERC721EnumerableUpgradeable.sol";
 import {IDatasetLinkInitializable} from "./IDatasetLinkInitializable.sol";
 
 /**
@@ -9,7 +11,7 @@ import {IDatasetLinkInitializable} from "./IDatasetLinkInitializable.sol";
  * @notice Defines functions available for Dataset Owner, Subscription Owners, and users
  * @dev Extends IDatasetLinkInitializable and IERC721
  */
-interface ISubscriptionManager is IDatasetLinkInitializable, IERC721 {
+interface ISubscriptionManager is IDatasetLinkInitializable, IERC721EnumerableUpgradeable {
   /**
    * @notice Verifies if a given subscription is paid for a specified consumer
    * @param dataset ID of the Dataset to access (ID of the target Dataset NFT token)

--- a/contracts/subscription/ERC20SubscriptionManager.sol
+++ b/contracts/subscription/ERC20SubscriptionManager.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {IDistributionManager} from "../interfaces/IDistributionManager.sol";
 import {GenericSingleDatasetSubscriptionManager} from "./GenericSingleDatasetSubscriptionManager.sol";
 
@@ -35,7 +34,7 @@ contract ERC20SubscriptionManager is GenericSingleDatasetSubscriptionManager {
   IERC20 public token;
   uint256 public feePerConsumerPerDay;
 
-  constructor() ERC721(_NAME, _SYMBOL) {
+  constructor() {
     _disableInitializers();
   }
 
@@ -47,6 +46,7 @@ contract ERC20SubscriptionManager is GenericSingleDatasetSubscriptionManager {
    * @param datasetId_ The ID of the Dataset NFT token
    */
   function initialize(address dataset_, uint256 datasetId_) external initializer {
+    __ERC721_init(_NAME, _SYMBOL);
     __GenericSubscriptionManager_init(dataset_, datasetId_);
   }
 

--- a/contracts/subscription/GenericSingleDatasetSubscriptionManager.sol
+++ b/contracts/subscription/GenericSingleDatasetSubscriptionManager.sol
@@ -2,9 +2,11 @@
 pragma solidity ^0.8.0;
 
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {
+  ERC721EnumerableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import {ISubscriptionManager} from "../interfaces/ISubscriptionManager.sol";
 import {IDatasetNFT} from "../interfaces/IDatasetNFT.sol";
 import {
@@ -19,10 +21,10 @@ import {
  * have unique IDs which are the respective minted ERC721 tokens' IDs.
  */
 abstract contract GenericSingleDatasetSubscriptionManager is
-  ISubscriptionManager,
   Initializable,
-  ERC721Enumerable,
-  ERC2771ContextExternalForwarderSourceUpgradeable
+  ERC721EnumerableUpgradeable,
+  ERC2771ContextExternalForwarderSourceUpgradeable,
+  ISubscriptionManager
 {
   using EnumerableSet for EnumerableSet.AddressSet;
   using EnumerableSet for EnumerableSet.UintSet;
@@ -80,6 +82,7 @@ abstract contract GenericSingleDatasetSubscriptionManager is
   function __GenericSubscriptionManager_init(address dataset_, uint256 datasetId_) internal onlyInitializing {
     __ERC2771ContextExternalForwarderSourceUpgradeable_init_unchained(dataset_);
     __GenericSubscriptionManager_init_unchained(dataset_, datasetId_);
+    __ERC721Enumerable_init_unchained();
   }
 
   /**
@@ -463,7 +466,7 @@ abstract contract GenericSingleDatasetSubscriptionManager is
     internal
     view
     virtual
-    override(Context, ERC2771ContextExternalForwarderSourceUpgradeable)
+    override(ContextUpgradeable, ERC2771ContextExternalForwarderSourceUpgradeable)
     returns (address sender)
   {
     return ERC2771ContextExternalForwarderSourceUpgradeable._msgSender();
@@ -473,7 +476,7 @@ abstract contract GenericSingleDatasetSubscriptionManager is
     internal
     view
     virtual
-    override(Context, ERC2771ContextExternalForwarderSourceUpgradeable)
+    override(ContextUpgradeable, ERC2771ContextExternalForwarderSourceUpgradeable)
     returns (bytes calldata)
   {
     return ERC2771ContextExternalForwarderSourceUpgradeable._msgData();


### PR DESCRIPTION
## Summary
 
- [x] added `ERC721EnumerableUpgradeable` and `ContextUpgradeable` in `GenericSingleDatasetSubscriptionManager`
- [x] adjusted `ISubscriptionManager` interface with correct interface `IERC721EnumerableUpgradeable`
- [x] init ERC721 correctly on `ERC20SubscriptionManager`

resolves #51 