### PR TITLE
refactor: start snapshots from index 1

### DIFF
--- a/contracts/FragmentNFT.sol
+++ b/contracts/FragmentNFT.sol
@@ -109,6 +109,7 @@ contract FragmentNFT is IFragmentNFT, ERC721Upgradeable, ERC2771ContextExternalF
     dataset = IDatasetNFT(dataset_);
     datasetId = datasetId_;
     _snapshots.push();
+    _snapshots.push();
   }
 
   /**
@@ -613,8 +614,8 @@ contract FragmentNFT is IFragmentNFT, ERC721Upgradeable, ERC2771ContextExternalF
    * @param arr The dynamic integer array from which to retrieve the last element
    * @return uint256 The value of the last element in the array
    */
-  function _lastUint256ArrayElement(uint256[] storage arr) private returns (uint256) {
-    if (arr.length == 0) arr.push();
+  function _lastUint256ArrayElement(uint256[] storage arr) private view returns (uint256) {
+    if (arr.length == 0) return 0;
 
     unchecked {
       return arr[arr.length - 1];

--- a/tests/FragmentNFT.spec.ts
+++ b/tests/FragmentNFT.spec.ts
@@ -285,7 +285,7 @@ export default async function suite(): Promise<void> {
 
     it('Should currentSnapshotId() return the correct index of Snapshots array', async () => {
       // Currently only 1 element is pushed into the snapshots array (during initialize() call)
-      const expectedIndex = 0;
+      const expectedIndex = 1;
 
       const idx = await DatasetFragment_.currentSnapshotId();
       expect(idx).to.equal(expectedIndex);


### PR DESCRIPTION
## Summary
 
- [x] started snapshots from index 1, instead of 0 adding extra  `_snapshots.push()` in the `initialize()` function
- [x] `_lastUint256ArrayElement()` now returns 0 if `arr.length == 0` instead of pushing empty array
- [x] adjusted test

resolves #64 