### PR TITLE
fix: prevent reentrancy in proposeMany() checking _mintCounter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "solidity.compileUsingRemoteVersion": "v0.8.18+commit.87f61d96"
+}

--- a/contracts/FragmentNFT.sol
+++ b/contracts/FragmentNFT.sol
@@ -313,8 +313,8 @@ contract FragmentNFT is IFragmentNFT, ERC721Upgradeable, ERC2771ContextExternalF
       if (owner == address(0)) {
         unchecked {
           i++;
+          skippedOwners++;
         }
-        skippedOwners++;
         continue;
       }
 


### PR DESCRIPTION
## Summary
 
- [x] added `lastMintCounter` to cache `_mintCounter` before loop
- [x] added `skippedOwners` to keep track how many zero addresses owner has been skipped
- [x] added check to ensure that tags has been proposed correctly

resolves #48 