### PR TITLE
fix: add fragment check in modifiers and add tests in AcceptManuallyVerifier

### DIFF
--- a/tests/FragmentNFT.spec.ts
+++ b/tests/FragmentNFT.spec.ts
@@ -357,6 +357,18 @@ export default async function suite(): Promise<void> {
         .withArgs(fragmentIds_[0]);
     });
 
+    it('Should revert data set owner resolve fragment propose if fragment address is incorrect - AcceptManuallyVerifier', async function () {
+      const invalidFragmentAddress = await DatasetNFT_.fragmentImplementation();
+
+      await expect(
+        AcceptManuallyVerifier_.connect(users_.datasetOwner).resolve(
+          invalidFragmentAddress,
+          fragmentIds_[0],
+          true
+        )
+      ).to.be.revertedWithCustomError(AcceptManuallyVerifier_, 'INVALID_FRAGMENT_NFT');
+    });
+
     it('Should data set owner accept multiple fragments proposes', async function () {
       const fragmentAddress = await DatasetNFT_.fragments(datasetId_);
       const DatasetFragment = await ethers.getContractAt('FragmentNFT', fragmentAddress);


### PR DESCRIPTION
## Summary
 
- [x] added check for validate fragmentNFT correctly in modifiers `onlyVerifierManager` and `onlyDatasetOwner`

Note: as we use modifiers in all external functions of `AcceptManuallyVerifier`, should satisfy all issue locations

resolves #40 