### PR TITLE
docs(natspec): add restrictive fee-on-transfer comment

### DIFF
--- a/contracts/distribution/DistributionManager.sol
+++ b/contracts/distribution/DistributionManager.sol
@@ -199,6 +199,7 @@ contract DistributionManager is
    * @notice Receives a subscription payment, sends deployer fee to configured beneficiary, and
    * creates a record of the amounts eligible for claiming by the Dataset owner and contributors respectively.
    * @dev Called by SubscriptionManager when a subscription payment is initiated.
+   * `token` must not contain fee-on-transfer mechanism.
    * If `token` is address(0) (indicating native currency), the `amount` should match the `msg.value`,
    * otherwise DistributionManager should call `transferFrom()` to transfer the amount from sender.
    * Emits {PaymentReceived} and {PayoutSent} events.

--- a/contracts/subscription/ERC20SubscriptionManager.sol
+++ b/contracts/subscription/ERC20SubscriptionManager.sol
@@ -32,7 +32,7 @@ contract ERC20SubscriptionManager is GenericSingleDatasetSubscriptionManager {
   error UNSUPPORTED_NATIVE_CURRENCY();
   error UNSUPPORTED_MSG_VALUE();
 
-  IERC20 public token;
+  IERC20 public token; // IERC20 token must not contain fee-on-transfer mechanism
   uint256 public feePerConsumerPerDay;
 
   constructor() ERC721(_NAME, _SYMBOL) {
@@ -54,6 +54,7 @@ contract ERC20SubscriptionManager is GenericSingleDatasetSubscriptionManager {
    * @notice Sets the daily subscription fee for a single consumer
    * @dev Only callable by the Dataset owner.
    * `token_` must be approved by DatasetNFT ADMIN (see `DatasetNFT.sol`).
+   * `token_` must not contain fee-on-transfer mechanism
    * `address(0)` (indicating natice currency) is not supported by this SubscriptionManager implementation.
    * @param token_ The address of the ERC20 token to be used for subscription payments
    * @param feePerConsumerPerDay_ The fee to set


### PR DESCRIPTION
## Summary

We decided to not support tokens with `fee-on-transfer` mechanism
 
- [x] added comments regarding not supporting `fee-on-transfer` tokens mechanism

resolves #43 