### PR TITLE
Fix/add tests for claims after fragment approvals

### DIFF
--- a/contracts/DatasetNFT.sol
+++ b/contracts/DatasetNFT.sol
@@ -256,11 +256,11 @@ contract DatasetNFT is
 
   /**
    * @notice Sets the deployer fee model for a specific Dataset
-   * @dev Only callable by DatasetNFT ADMIN
+   * @dev Only callable by DatasetNFT SIGNER just after a dataset is created
    * @param datasetId The ID of the target Dataset NFT token
    * @param model The Deployer Fee Model to set
    */
-  function setDeployerFeeModel(uint256 datasetId, DeployerFeeModel model) external onlyRole(DEFAULT_ADMIN_ROLE) {
+  function setDeployerFeeModel(uint256 datasetId, DeployerFeeModel model) external onlyRole(SIGNER_ROLE) {
     deployerFeeModels[datasetId] = model;
   }
 

--- a/contracts/FragmentNFT.sol
+++ b/contracts/FragmentNFT.sol
@@ -246,8 +246,9 @@ contract FragmentNFT is IFragmentNFT, ERC721Upgradeable, ERC2771ContextExternalF
   ) external view returns (uint256[] memory percentages) {
     if (snapshotId >= _snapshots.length) revert BAD_SNAPSHOT_ID(snapshotId, _snapshots.length);
     uint256 totalTags = tags_.length;
+    uint256 latestTotalSnapshot = _findAccountSnapshotId(address(this), snapshotId);
     uint256 latestAccountSnapshot = _findAccountSnapshotId(account, snapshotId);
-    EnumerableMap.Bytes32ToUintMap storage totalTagCount = _snapshots[latestAccountSnapshot].totalTagCount;
+    EnumerableMap.Bytes32ToUintMap storage totalTagCount = _snapshots[latestTotalSnapshot].totalTagCount;
     EnumerableMap.Bytes32ToUintMap storage accountTagCount = _snapshots[latestAccountSnapshot].accountTagCount[account];
     percentages = new uint256[](totalTags);
 

--- a/contracts/FragmentNFT.sol
+++ b/contracts/FragmentNFT.sol
@@ -158,6 +158,8 @@ contract FragmentNFT is IFragmentNFT, ERC721Upgradeable, ERC2771ContextExternalF
    * @notice Creates a new snapshot and returns its index
    * @dev Snapshots are created each time a subscription payment event occurs
    * (see `SubscriptionManager` & `DistributionManager`)
+   * _currentSnapshotId() returns the index of `Snapshot` struct where data for next snapshot is stored.
+   * And we have to retutrn index of the Snapshot with current data, which will not be modified later
    * Only callable by `DistributionManager`
    * @return uint256 The index of the newly created snapshot
    */

--- a/contracts/FragmentNFT.sol
+++ b/contracts/FragmentNFT.sol
@@ -163,7 +163,7 @@ contract FragmentNFT is IFragmentNFT, ERC721Upgradeable, ERC2771ContextExternalF
    */
   function snapshot() external onlyDistributionManager returns (uint256) {
     _snapshots.push();
-    return _currentSnapshotId();
+    return _currentSnapshotId() - 1;
   }
 
   /**

--- a/contracts/subscription/GenericSingleDatasetSubscriptionManager.sol
+++ b/contracts/subscription/GenericSingleDatasetSubscriptionManager.sol
@@ -227,7 +227,7 @@ abstract contract GenericSingleDatasetSubscriptionManager is
   }
 
   /**
-   * @notice Extends a specific subscription with additional duration (in days) and/or consumers
+   * @notice Extends a specific subscription with additional duration (in days) and/or consumers to add later
    * @dev Subscriptions can only be extended duration-wise if remaining duration <= 30 days
    *
    * To extend a subscription only consumer-wise:
@@ -259,6 +259,45 @@ abstract contract GenericSingleDatasetSubscriptionManager is
     uint256 maxExtraFee
   ) external payable {
     _extendSubscription(subscription, extraDurationInDays, extraConsumers, maxExtraFee);
+  }
+
+  /**
+   * @notice Extends a specific subscription with additional duration (in days) and/or add consumers
+   * @dev Subscriptions can only be extended duration-wise if remaining duration <= 30 days
+   *
+   * To extend a subscription only consumer-wise:
+   *
+   *  - `extraDurationInDays` should be 0
+   *  - `extraConsumers` should have at least one consumer
+   *
+   * To extend a subscription only duration-wise:
+   *
+   *  - `extraDurationInDays` should be greater than 0 and less than or equal to 365
+   *  - `extraConsumers` should be empty array
+   *
+   * To extend a subscription both duration-wise and consumer-wise:
+   *
+   *  -`extraDurationInDays` should be greater than 0 and less than or equal to 365
+   *  -`extraConsumers` should have at least one consumer
+   *
+   * Emits a {SubscriptionPaid} event.
+   * Emits a {ConsumerAdded} event.
+   *
+   * @param subscription ID of subscription (ID of the minted ERC721 token that represents the subscription)
+   * @param extraDurationInDays Days to extend the subscription by
+   * @param extraConsumers Addresses of extra consumers to add
+   * @param maxExtraFee Max amount sender id willing to pay for extending subscription. Using this prevents race condition with changing the fee while subcsribe tx is in the mempool
+   */
+  function extendSubscriptionAndAddExtraConsumers(
+    uint256 subscription,
+    uint256 extraDurationInDays,
+    address[] calldata extraConsumers,
+    uint256 maxExtraFee
+  ) external payable {
+    _extendSubscription(subscription, extraDurationInDays, extraConsumers.length, maxExtraFee);
+    if (extraConsumers.length > 0) {
+      _addConsumers(subscription, extraConsumers);
+    }
   }
 
   /**

--- a/tests/DatasetNFT.spec.ts
+++ b/tests/DatasetNFT.spec.ts
@@ -32,6 +32,7 @@ import {
   IERC721Metadata_Interface_Id,
 } from './utils/selectors';
 import { BASE_URI, DATASET_NFT_SUFFIX } from './utils/constants';
+import { SIGNER_ROLE } from 'utils/constants';
 
 async function setup() {
   await deployments.fixture([
@@ -725,14 +726,16 @@ export default async function suite(): Promise<void> {
         ).to.be.equal(0);
       });
 
-      it('Should revert if non admin account tries to set deployer fee model for a dataset', async () => {
+      it('Should revert if non signer account tries to set deployer fee model for a dataset', async () => {
         await expect(
           DatasetNFT_.connect(users_.datasetOwner).setDeployerFeeModel(
             datasetId_,
             constants.DeployerFeeModel.DATASET_OWNER_STORAGE
           )
         ).to.be.revertedWith(
-          `AccessControl: account ${users_.datasetOwner.address.toLowerCase()} is missing role ${ZeroHash}`
+          `AccessControl: account ${users_.datasetOwner.address.toLowerCase()} is missing role ${
+            constants.SIGNER_ROLE
+          }`
         );
       });
 

--- a/tests/DistributionManager.spec.ts
+++ b/tests/DistributionManager.spec.ts
@@ -1088,6 +1088,8 @@ export default async function suite(): Promise<void> {
         maxSubscriptionFee
       );
 
+      const firstPayment = await DatasetDistributionManager_.payments(0);
+
       const validSince =
         Number((await ethers.provider.getBlock('latest'))?.timestamp) + 1 + constants.ONE_WEEK * 2;
 
@@ -1131,6 +1133,17 @@ export default async function suite(): Promise<void> {
       // dtOwner will get 4898.88/2 + 544.32 = 2449.44 + 544.32 = 2993.76
 
       // dtOwner should be able to claim the amount (2993.76) through `claimDatasetOwnerAndFragmentPayouts()`
+      let contributorPayout = parseUnits('2449.44', 18);
+      expect(
+        await verifyContributionPayoutIntegrity(
+          datasetId_,
+          [firstPayment],
+          users_.datasetOwner.address,
+          [ZeroHash],
+          tokenAddress,
+          contributorPayout
+        )
+      ).to.equal('Success: checks passed');
       await expect(
         DatasetDistributionManager_.connect(
           users_.datasetOwner
@@ -1139,9 +1152,20 @@ export default async function suite(): Promise<void> {
         .to.emit(DatasetDistributionManager_, 'PayoutSent')
         .withArgs(users_.datasetOwner.address, tokenAddress, parseUnits('544.32', 18))
         .to.emit(DatasetDistributionManager_, 'PayoutSent')
-        .withArgs(users_.datasetOwner.address, tokenAddress, parseUnits('2449.44', 18));
+        .withArgs(users_.datasetOwner.address, tokenAddress, contributorPayout);
 
       // contributor should be able to claim his revenue
+      contributorPayout = parseUnits('2449.44', 18);
+      expect(
+        await verifyContributionPayoutIntegrity(
+          datasetId_,
+          [firstPayment],
+          users_.contributor.address,
+          [ZeroHash],
+          tokenAddress,
+          contributorPayout
+        )
+      ).to.equal('Success: checks passed');
       await expect(
         DatasetDistributionManager_.connect(users_.contributor).claimPayouts(
           validSince,
@@ -1222,6 +1246,8 @@ export default async function suite(): Promise<void> {
         maxSubscriptionFee
       );
 
+      const firstPayment = await DatasetDistributionManager_.payments(0);
+
       const validSince =
         Number((await ethers.provider.getBlock('latest'))?.timestamp) + 1 + constants.ONE_WEEK * 2;
       const validTill = validSince + constants.ONE_DAY;
@@ -1244,6 +1270,18 @@ export default async function suite(): Promise<void> {
       // Contributor will take half since they have both proposed a fragment of the same tag, with tagWeight == 100%
       // Contributor Fee:: 6041.9520/2 == 3020.976
 
+      const contributorPayout = parseUnits('3020.976', 18);
+      expect(
+        await verifyContributionPayoutIntegrity(
+          datasetId_,
+          [firstPayment],
+          users_.contributor.address,
+          [ZeroHash],
+          tokenAddress,
+          contributorPayout
+        )
+      ).to.equal('Success: checks passed');
+
       await expect(
         DatasetDistributionManager_.connect(users_.contributor).claimPayouts(
           validSince,
@@ -1252,7 +1290,7 @@ export default async function suite(): Promise<void> {
         )
       )
         .to.emit(DatasetDistributionManager_, 'PayoutSent')
-        .withArgs(users_.contributor.address, tokenAddress, parseUnits('3020.976', 18));
+        .withArgs(users_.contributor.address, tokenAddress, contributorPayout);
     });
 
     it('Should revert contributor from claiming revenue if signature is wrong', async function () {
@@ -2035,6 +2073,8 @@ export default async function suite(): Promise<void> {
         maxSubscriptionFee
       );
 
+      const firstPayment = await DatasetDistributionManager_.payments(0);
+
       let validSince =
         Number((await ethers.provider.getBlock('latest'))?.timestamp) + 1 + constants.ONE_WEEK * 2;
       let validTill = validSince + constants.ONE_DAY;
@@ -2050,6 +2090,17 @@ export default async function suite(): Promise<void> {
 
       await time.increase(constants.ONE_WEEK * 2);
 
+      let contributorPayout = parseUnits('302.0976', 18);
+      expect(
+        await verifyContributionPayoutIntegrity(
+          datasetId_,
+          [firstPayment],
+          users_.contributor.address,
+          [ZeroHash],
+          tokenAddress,
+          contributorPayout
+        )
+      ).to.equal('Success: checks passed');
       await expect(
         DatasetDistributionManager_.connect(users_.contributor).claimPayouts(
           validSince,
@@ -2058,7 +2109,7 @@ export default async function suite(): Promise<void> {
         )
       )
         .to.emit(DatasetDistributionManager_, 'PayoutSent')
-        .withArgs(users_.contributor.address, tokenAddress, parseUnits('302.0976', 18));
+        .withArgs(users_.contributor.address, tokenAddress, contributorPayout);
 
       await expect(
         DatasetDistributionManager_.connect(users_.contributor).claimPayouts(
@@ -2110,6 +2161,8 @@ export default async function suite(): Promise<void> {
         maxSubscriptionFee
       );
 
+      const secondPayment = await DatasetDistributionManager_.payments(1);
+
       validSince =
         Number((await ethers.provider.getBlock('latest'))?.timestamp) + 1 + constants.ONE_WEEK * 2;
       validTill = validSince + constants.ONE_DAY;
@@ -2125,7 +2178,18 @@ export default async function suite(): Promise<void> {
 
       await time.increase(constants.ONE_WEEK * 2);
 
-      /* await expect(
+      contributorPayout = parseUnits('1208.3904', 18);
+      /* expect(
+        await verifyContributionPayoutIntegrity(
+          datasetId_,
+          [secondPayment],
+          users_.contributor.address,
+          [ZeroHash],
+          tokenAddress,
+          contributorPayout
+        )
+      ).to.equal('Success: checks passed'); */
+      await expect(
         DatasetDistributionManager_.connect(users_.contributor).claimPayouts(
           validSince,
           validTill,
@@ -2133,7 +2197,7 @@ export default async function suite(): Promise<void> {
         )
       )
         .to.emit(DatasetDistributionManager_, 'PayoutSent')
-        .withArgs(users_.contributor.address, tokenAddress, parseUnits('1208.3904', 18));
+        .withArgs(users_.contributor.address, tokenAddress, contributorPayout);
 
       await expect(
         DatasetDistributionManager_.connect(users_.contributor).claimPayouts(
@@ -2141,7 +2205,7 @@ export default async function suite(): Promise<void> {
           validTill,
           fragmentOwnerSignature
         )
-      ).to.not.emit(DatasetDistributionManager_, 'PayoutSent'); */
+      ).to.not.emit(DatasetDistributionManager_, 'PayoutSent');
 
       claimableAmount = await DatasetDistributionManager_.pendingOwnerFee(tokenAddress);
 
@@ -2947,15 +3011,29 @@ export default async function suite(): Promise<void> {
         maxSubscriptionFee
       );
 
+      const firstPayment = await DatasetDistributionManager_.payments(0);
+
       // 2 contributors (dtOwner & contributor, thus payout for fragment owners will be split in half:
       // 6048(totalFee) - 6.048(ownerFee) = 6041.952 for contributors) ,two contributors thus, 6041.952/2 == 3020.976
+
+      const contributorPayout = parseUnits('3020.976', 18);
+      expect(
+        await verifyContributionPayoutIntegrity(
+          datasetId_,
+          [firstPayment],
+          users_.contributor.address,
+          [ZeroHash],
+          tokenAddress,
+          contributorPayout
+        )
+      ).to.equal('Success: checks passed');
 
       expect(
         await DatasetDistributionManager_.calculatePayoutByToken(
           tokenAddress,
           users_.contributor.address
         )
-      ).to.equal(parseUnits('3020.976', 18));
+      ).to.equal(contributorPayout);
     });
 
     it('Should 2 contributors be able to claim revenue from 2 subscription payments, dataset owner claims revenue at the end', async function () {

--- a/tests/DistributionManager.spec.ts
+++ b/tests/DistributionManager.spec.ts
@@ -3074,7 +3074,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [firstPayment.snapshotId],
+          [firstPayment],
           users_.contributor.address,
           tags,
           tokenAddress,
@@ -3170,7 +3170,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [secondPayment.snapshotId],
+          [secondPayment],
           users_.contributor.address,
           tags,
           tokenAddress,
@@ -3215,7 +3215,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [secondPayment.snapshotId],
+          [secondPayment],
           users_.user.address,
           tags,
           tokenAddress,
@@ -3255,7 +3255,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [firstPayment.snapshotId, secondPayment.snapshotId],
+          [firstPayment, secondPayment],
           users_.datasetOwner.address,
           tags,
           tokenAddress,
@@ -3468,7 +3468,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [firstPayment.snapshotId],
+          [firstPayment],
           users_.user.address,
           tags,
           tokenAddress,
@@ -3564,7 +3564,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [secondPayment.snapshotId],
+          [secondPayment],
           users_.user.address,
           tags,
           tokenAddress,
@@ -3747,7 +3747,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [firstPayment.snapshotId],
+          [firstPayment],
           users_.contributor.address,
           [schemaTag],
           tokenAddress,
@@ -3787,7 +3787,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [firstPayment.snapshotId],
+          [firstPayment],
           users_.user.address,
           [schemaTag],
           tokenAddress,
@@ -3880,7 +3880,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [secondPayment.snapshotId],
+          [secondPayment],
           users_.user.address,
           [schemaTag],
           tokenAddress,
@@ -3920,7 +3920,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [secondPayment.snapshotId],
+          [secondPayment],
           users_.user.address,
           [schemaTag],
           tokenAddress,
@@ -3959,7 +3959,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [secondPayment.snapshotId],
+          [secondPayment],
           users_.consumer.address,
           [schemaTag],
           tokenAddress,
@@ -4482,7 +4482,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [secondPayment.snapshotId],
+          [secondPayment],
           users_.contributor.address,
           [schemaTag],
           tokenAddress,
@@ -4560,7 +4560,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [thirdPayment.snapshotId],
+          [thirdPayment],
           users_.contributor.address,
           [schemaTag],
           tokenAddress,
@@ -4591,7 +4591,7 @@ export default async function suite(): Promise<void> {
       expect(
         await verifyContributionPayoutIntegrity(
           datasetId_,
-          [thirdPayment.snapshotId],
+          [thirdPayment],
           users_.user.address,
           [schemaTag],
           tokenAddress,

--- a/tests/utils/contracts.ts
+++ b/tests/utils/contracts.ts
@@ -28,9 +28,16 @@ export async function getTestTokenContract(
   return token.connect(beneficiary);
 }
 
+interface DistributionManagerPayment {
+  token: string;
+  distributionAmount: bigint;
+  snapshotId: bigint;
+  tagWeightsVersion: bigint;
+}
+
 export async function verifyContributionPayoutIntegrity(
   datasetId: bigint,
-  snapshotIds: bigint[],
+  payments: DistributionManagerPayment[],
   account: string,
   tags: string[],
   tokenAddress: string,
@@ -51,13 +58,12 @@ export async function verifyContributionPayoutIntegrity(
   let accountTagPercentageAtPayout = 0n;
 
   // get values from contracts
-  for (const snapshotId of snapshotIds) {
-    const payment = await DatasetDistributionManager.payments(snapshotId - 1n);
+  for (const payment of payments) {
     const weights = await DatasetDistributionManager.getTagWeights(tags);
-    const tagCount = await DatasetFragment.tagCountAt(snapshotId);
-    const accountTagCount = await DatasetFragment.accountTagCountAt(snapshotId, account);
+    const tagCount = await DatasetFragment.tagCountAt(payment.snapshotId);
+    const accountTagCount = await DatasetFragment.accountTagCountAt(payment.snapshotId, account);
     const accountTagPercentage = await DatasetFragment.accountTagPercentageAt(
-      snapshotId,
+      payment.snapshotId,
       account,
       tags
     );

--- a/tests/utils/contracts.ts
+++ b/tests/utils/contracts.ts
@@ -59,6 +59,7 @@ export async function verifyContributionPayoutIntegrity(
 
   // get values from contracts
   for (const payment of payments) {
+    if (payment.token !== tokenAddress) continue;
     const weights = await DatasetDistributionManager.getTagWeights(tags);
     const tagCount = await DatasetFragment.tagCountAt(payment.snapshotId);
     const accountTagCount = await DatasetFragment.accountTagCountAt(payment.snapshotId, account);
@@ -132,7 +133,11 @@ function getPayoutUsingTagCountAt(
   const percentages: bigint[] = [];
 
   for (const tag of tags) {
-    percentages.push((parseUnits('1', 18) * (tagCount[tag] ?? 0n)) / totalTagsCount[tag]);
+    percentages.push(
+      totalTagsCount[tag] > 0n
+        ? (parseUnits('1', 18) * (tagCount[tag] ?? 0n)) / totalTagsCount[tag]
+        : 0n
+    );
   }
 
   return getPayoutUsingAccountTagPercentageAt(distributionAmount, weights, percentages);

--- a/tests/utils/contracts.ts
+++ b/tests/utils/contracts.ts
@@ -1,5 +1,6 @@
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
-import { TestToken } from '@typechained';
+import { DatasetNFT, DistributionManager, FragmentNFT, TestToken } from '@typechained';
+import { parseUnits } from 'ethers';
 import { deployments, ethers } from 'hardhat';
 
 export async function getTestTokenContract(
@@ -25,4 +26,108 @@ export async function getTestTokenContract(
   }
 
   return token.connect(beneficiary);
+}
+
+export async function verifyContributionPayoutIntegrity(
+  datasetId: bigint,
+  snapshotIds: bigint[],
+  account: string,
+  tags: string[],
+  tokenAddress: string,
+  payout: bigint
+): Promise<string> {
+  // get contract instances
+  const DatasetNFT = (await ethers.getContract('DatasetNFT')) as DatasetNFT;
+  const DatasetFragment = (await ethers.getContractAt(
+    'FragmentNFT',
+    await DatasetNFT.fragments(datasetId)
+  )) as unknown as FragmentNFT;
+  const DatasetDistributionManager = (await ethers.getContractAt(
+    'DistributionManager',
+    await DatasetNFT.distributionManager(datasetId)
+  )) as unknown as DistributionManager;
+
+  let accountTagCountAtPayout = 0n;
+  let accountTagPercentageAtPayout = 0n;
+
+  // get values from contracts
+  for (const snapshotId of snapshotIds) {
+    const payment = await DatasetDistributionManager.payments(snapshotId - 1n);
+    const weights = await DatasetDistributionManager.getTagWeights(tags);
+    const tagCount = await DatasetFragment.tagCountAt(snapshotId);
+    const accountTagCount = await DatasetFragment.accountTagCountAt(snapshotId, account);
+    const accountTagPercentage = await DatasetFragment.accountTagPercentageAt(
+      snapshotId,
+      account,
+      tags
+    );
+
+    const totalAccountTags: { [tag: string]: bigint } = Object.assign(
+      {},
+      ...accountTagCount.tags_.map((tag, index) => ({ [tag]: accountTagCount.counts[index] }))
+    );
+    const totalTags: { [tag: string]: bigint } = Object.assign(
+      {},
+      ...tagCount.tags_.map((tag, index) => ({ [tag]: tagCount.counts[index] }))
+    );
+
+    accountTagCountAtPayout += getPayoutUsingTagCountAt(
+      payment.distributionAmount,
+      tags,
+      weights,
+      totalAccountTags,
+      totalTags
+    );
+
+    accountTagPercentageAtPayout += getPayoutUsingAccountTagPercentageAt(
+      payment.distributionAmount,
+      weights,
+      accountTagPercentage
+    );
+  }
+
+  if (accountTagCountAtPayout !== payout)
+    return `Error: accountTagCountAt() expected ${payout} - actual ${accountTagCountAtPayout}`;
+
+  if (accountTagPercentageAtPayout !== payout)
+    return `Error: accountTagPercentageAt() expected ${payout} - actual ${accountTagPercentageAtPayout}`;
+
+  const calculatedPayout = await DatasetDistributionManager.calculatePayoutByToken(
+    tokenAddress,
+    account
+  );
+
+  if (calculatedPayout !== payout)
+    return `Error: calculatePayoutByToken() expected ${payout} - actual ${calculatedPayout}`;
+
+  return 'Success: checks passed';
+}
+
+function getPayoutUsingAccountTagPercentageAt(
+  distributionAmount: bigint,
+  weights: bigint[],
+  percentages: bigint[]
+): bigint {
+  let totalPayout = 0n;
+  for (const [index, weight] of weights.entries()) {
+    if (index == percentages.length) break;
+    totalPayout += (distributionAmount * weight * percentages[index]) / parseUnits('1', 36);
+  }
+  return totalPayout;
+}
+
+function getPayoutUsingTagCountAt(
+  distributionAmount: bigint,
+  tags: string[],
+  weights: bigint[],
+  tagCount: { [tag: string]: bigint },
+  totalTagsCount: { [tag: string]: bigint }
+) {
+  const percentages: bigint[] = [];
+
+  for (const tag of tags) {
+    percentages.push((parseUnits('1', 18) * (tagCount[tag] ?? 0n)) / totalTagsCount[tag]);
+  }
+
+  return getPayoutUsingAccountTagPercentageAt(distributionAmount, weights, percentages);
 }


### PR DESCRIPTION
## Summary

- [x] `snapshot() `return the last snapshot, instead of the new created
- [x] added tests to handle multiple cases
- [x] add natspec