### PR TITLE
Fix C-01 Frontrun and parameter modification in mintAndConfigureDataset function

### DIFF
--- a/contracts/interfaces/IDatasetNFT.sol
+++ b/contracts/interfaces/IDatasetNFT.sol
@@ -43,10 +43,9 @@ interface IDatasetNFT is IERC721Upgradeable {
    * @dev Emits a {Transfer} event
    * @param uuidHashed The keccak256 hash of the off-chain generated UUID for the Dataset
    * @param to Dataset owner
-   * @param signature Signature from a DT service confirming creation of Dataset
    * @return uin256 ID of the minted token
    */
-  function mintByFactory(bytes32 uuidHashed, address to, bytes calldata signature) external returns (uint256);
+  function mintByFactory(bytes32 uuidHashed, address to, address signer) external returns (uint256);
 
   /**
    * @notice Sets and configures the Manager contracts for a specific Dataset NFT

--- a/deploy/006_deploy_DatasetFactory.ts
+++ b/deploy/006_deploy_DatasetFactory.ts
@@ -15,6 +15,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const deployedDatasetFactory = await deploy('DatasetFactory', {
     from: dtAdmin,
+    args: ["DatasetFactory", "1"],
   });
 
   console.log('DatasetFactory deployed successfully at', deployedDatasetFactory.address);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -24,6 +24,7 @@ const config: HardhatUserConfig = {
           yul: true, // this resolves the issue when running coverage `Stack too deep when compiling inline assembly: Variable headStart is 1 slot(s) too deep inside the stack`
         },
       },
+      viaIR: true,
     },
     overrides: {
       'contracts/DatasetFactory.sol': {

--- a/tests/DatasetNFT.spec.ts
+++ b/tests/DatasetNFT.spec.ts
@@ -105,13 +105,13 @@ const setupOnMint = async () => {
     await DatasetFactory.connect(users.datasetOwner).mintAndConfigureDataset(
       uuidHash,
       users.datasetOwner.address,
-      signedMessage,
       defaultVerifierAddress,
       await users.datasetOwner.Token!.getAddress(),
       feeAmount,
       dsOwnerPercentage,
       [ZeroHash],
-      [parseUnits('1', 18)]
+      [parseUnits('1', 18)],
+      signedMessage
     )
   ).wait();
 
@@ -194,6 +194,7 @@ export default async function suite(): Promise<void> {
       const NewDatasetFactory = await deployments.deploy('DatasetFactory_new', {
         contract: 'DatasetFactory',
         from: users_.dtAdmin.address,
+        args: ["DatasetFactory", "1"],
       });
 
       await DatasetNFT_.connect(users_.dtAdmin).setDatasetFactory(NewDatasetFactory.address);
@@ -400,13 +401,13 @@ export default async function suite(): Promise<void> {
         DatasetFactory_.connect(users_.datasetOwner).mintAndConfigureDataset(
           uuidHash,
           users_.datasetOwner.address,
-          signedMessage,
           defaultVerifierAddress,
           await users_.datasetOwner.Token!.getAddress(),
           feeAmount,
           dsOwnerPercentage,
           [ZeroHash],
-          [parseUnits('1', 18)]
+          [parseUnits('1', 18)],
+          signedMessage
         )
       )
         .to.emit(DatasetNFT_, 'ManagersConfigChange')
@@ -491,13 +492,13 @@ export default async function suite(): Promise<void> {
         DatasetFactory_.connect(users_.datasetOwner).mintAndConfigureDataset(
           uuidHash,
           users_.datasetOwner.address,
-          signedMessage,
           defaultVerifierAddress,
           await users_.datasetOwner.Token!.getAddress(),
           feeAmount,
           dsOwnerPercentage,
           [ZeroHash],
-          [parseUnits('1', 18)]
+          [parseUnits('1', 18)],
+          signedMessage
         )
       ).to.be.revertedWithCustomError(DatasetNFT_, 'DATASET_FACTORY_ZERO_ADDRESS');
     });
@@ -531,13 +532,13 @@ export default async function suite(): Promise<void> {
       await DatasetFactory_.connect(users_.datasetOwner).mintAndConfigureDataset(
         uuidHash,
         users_.datasetOwner.address,
-        signedMessage,
         defaultVerifierAddress,
         await users_.datasetOwner.Token!.getAddress(),
         feeAmount,
         dsOwnerPercentage,
         [ZeroHash],
-        [parseUnits('1', 18)]
+        [parseUnits('1', 18)],
+        signedMessage
       );
 
       // Same uuidHash used --> should revert since the same tokenId (uint256(uuidHash)) cannot be minted again
@@ -545,13 +546,13 @@ export default async function suite(): Promise<void> {
         DatasetFactory_.connect(users_.datasetOwner).mintAndConfigureDataset(
           uuidHash,
           users_.datasetOwner.address,
-          signedMessage,
           defaultVerifierAddress,
           await users_.datasetOwner.Token!.getAddress(),
           feeAmount,
           dsOwnerPercentage,
           [ZeroHash],
-          [parseUnits('1', 18)]
+          [parseUnits('1', 18)],
+          signedMessage
         )
       ).to.be.revertedWith('ERC721: token already minted');
     });
@@ -573,13 +574,13 @@ export default async function suite(): Promise<void> {
         DatasetFactory_.connect(users_.datasetOwner).mintAndConfigureDataset(
           uuidHash,
           users_.datasetOwner.address,
-          signedMessage,
           defaultVerifierAddress,
           await users_.datasetOwner.Token!.getAddress(),
           feeAmount,
           dsOwnerPercentage,
           [ZeroHash],
-          [parseUnits('1', 18)]
+          [parseUnits('1', 18)],
+          signedMessage
         )
       ).to.be.revertedWithCustomError(DatasetNFT_, 'BAD_SIGNATURE');
     });
@@ -608,13 +609,13 @@ export default async function suite(): Promise<void> {
         DatasetFactory_.connect(users_.datasetOwner).mintAndConfigureDataset(
           uuidHash,
           users_.datasetOwner.address,
-          signedMessage,
           defaultVerifierAddress,
           await users_.datasetOwner.Token!.getAddress(),
           feeAmount,
           dsOwnerPercentage,
           [ZeroHash],
-          [parseUnits('1', 18)]
+          [parseUnits('1', 18)],
+          signedMessage
         )
       ).to.be.revertedWithCustomError(DatasetNFT_, 'BAD_SIGNATURE');
     });
@@ -844,13 +845,13 @@ export default async function suite(): Promise<void> {
         await DatasetFactory_.connect(users_.dtAdmin).mintAndConfigureDataset(
           uuidHash,
           users_.datasetOwner.address,
-          signedMintMessage,
           defaultVerifierAddress,
           await users_.datasetOwner.Token!.getAddress(),
           feeAmount,
           dsOwnerPercentage,
           [ZeroHash],
-          [parseUnits('1', 18)]
+          [parseUnits('1', 18)],
+          signedMintMessage
         );
 
         // Now datasetOwner should be the owner of 2nd dataSetNFT
@@ -900,13 +901,13 @@ export default async function suite(): Promise<void> {
         await DatasetFactory_.connect(users_.dtAdmin).mintAndConfigureDataset(
           uuidHash,
           users_.datasetOwner.address,
-          signedMintMessage,
           defaultVerifierAddress,
           await users_.datasetOwner.Token!.getAddress(),
           feeAmount,
           dsOwnerPercentage,
           [ZeroHash],
-          [parseUnits('1', 18)]
+          [parseUnits('1', 18)],
+          signedMintMessage
         );
 
         // Now datasetOwner should be the owner of 2nd dataSetNFT

--- a/tests/DistributionManager.spec.ts
+++ b/tests/DistributionManager.spec.ts
@@ -67,13 +67,13 @@ const setup = async () => {
     await contracts.DatasetFactory.connect(users.datasetOwner).mintAndConfigureDataset(
       uuidHash,
       users.datasetOwner.address,
-      signedMessage,
       defaultVerifierAddress,
       await users.datasetOwner.Token!.getAddress(),
       feeAmount,
       dsOwnerPercentage,
       [ZeroHash],
-      [parseUnits('1', 18)]
+      [parseUnits('1', 18)],
+      signedMessage
     )
   ).wait();
 

--- a/tests/FragmentNFT.spec.ts
+++ b/tests/FragmentNFT.spec.ts
@@ -79,13 +79,13 @@ const setup = async () => {
     await contracts.DatasetFactory.connect(users.datasetOwner).mintAndConfigureDataset(
       uuidHash,
       users.datasetOwner.address,
-      signedMessage,
       defaultVerifierAddress,
       await users.subscriber.Token!.getAddress(),
       feeAmount,
       dsOwnerPercentage,
       [tag],
-      [parseUnits('1', 18)]
+      [parseUnits('1', 18)],
+      signedMessage
     )
   ).wait();
 

--- a/tests/SubscriptionManager.spec.ts
+++ b/tests/SubscriptionManager.spec.ts
@@ -66,13 +66,13 @@ const setup = async () => {
     await contracts.DatasetFactory.connect(users.datasetOwner).mintAndConfigureDataset(
       uuidHash,
       users.datasetOwner.address,
-      signedMessage,
       defaultVerifierAddress,
       await users.datasetOwner.Token!.getAddress(),
       feeAmount,
       dsOwnerPercentage,
       [ZeroHash],
-      [parseUnits('1', 18)]
+      [parseUnits('1', 18)],
+      signedMessage
     )
   ).wait();
 


### PR DESCRIPTION
1. Moved the responsibility of the signature check to the factory
2. The DatasetNFT receives the signer and checks it, since it has the AccessControlUpgradeable logic.
3. Modify the signature system to respect the EIP712 standard.

I also had to add the `viaIR` to avoid the stack to deep error. 